### PR TITLE
Implement ability to add labels on the created secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ Optional parameters:
    This certificate should be shared with all users and each user should add it into OS or browser trust store.
    The namespace is defined by `CHE_NAMESPACE` environment variable.
    Default value is `self-signed-certificate`.
+ - `LABELS` is a space separated list of labels to add to the generated secret.
+   Could be empty.
 
 Image repository is `quay.io/eclipse/che-tls-secret-creator` and could be found [here](https://quay.io/repository/eclipse/che-tls-secret-creator).

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -144,5 +144,21 @@ if [ $? -ne 0 ]; then
     exit 21
 fi
 
+# Label the resulting secrets.
+# It is used to have the secret cached in the operator client.
+if [ -n "$LABELS" ]; then
+    kubectl label secret "${CHE_SERVER_TLS_SECRET_NAME}" ${LABELS} --namespace=$CHE_NAMESPACE
+    if [ $? -ne 0 ]; then
+        echo "Error while labeling secret \"${CHE_SERVER_TLS_SECRET_NAME}\"."
+        exit 22
+    fi
+
+    kubectl label secret "${CHE_CA_CERTIFICATE_SECRET_NAME}" ${LABELS} --namespace=$CHE_NAMESPACE
+    if [ $? -ne 0 ]; then
+        echo "Error while labeling secret \"${CHE_CA_CERTIFICATE_SECRET_NAME}\"."
+        exit 23
+    fi
+fi
+
 # Log that everything is done
 echo 'Che TLS secrets are created.'


### PR DESCRIPTION
Signed-off-by: Mykola Morhun <mmorhun@redhat.com>

#### What this PR does
This PR allows labeling created secrets. Needed to mark them as a part of Che installation, so Che operator client can cache them as well.

#### Referenced issue
https://github.com/eclipse/che/issues/20647
